### PR TITLE
Java 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ REQUIREMENTS:
 
 Minecraft 1.7.10
 
-Forge 1.7.10-10.13.4.1614 (possibly an earlier version will work)
+Forge 1.7.10-10.13.4.1614 (possibly an earlier version will work)`
+
+Java 8
 
 INSTALLATION:
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,9 @@ version = "1.0"
 group= "vulcanforge.pvp-mode-mod" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "pvp-mode"
 
+srcCompat = JavaVersion.VERSION_1_8
+targetCompat = JavaVersion.VERSION_1_8
+
 minecraft {
     version = "1.7.10-10.13.4.1614-1.7.10"
     runDir = "eclipse"


### PR DESCRIPTION
Added support for Java 8 - Gradle will now build the mod with Java 8 features.
@VulcanForge  and @Mahtaran You'll probably need to configure your IDE to use Java 8 - at least Eclipse shows errors because the default compilance level is set to Java 6.