### PR TITLE
Fixed that the chat text in sendCooldown was formatted wrongly

### DIFF
--- a/main/java/pvpmode/PvPEventHandler.java
+++ b/main/java/pvpmode/PvPEventHandler.java
@@ -237,8 +237,7 @@ public class PvPEventHandler
 
     void sendCooldown(EntityPlayerMP player)
     {
-        PvPUtils.yellow (player, "You can switch PvP modes again in \" + PvPMode.cooldown\n" +
-                        "                                        + \" seconds.");
+        PvPUtils.yellow (player, "You can switch PvP modes again in " + PvPMode.cooldown + " seconds");
     }
 
     public static void init()

--- a/main/java/pvpmode/PvPEventHandler.java
+++ b/main/java/pvpmode/PvPEventHandler.java
@@ -235,11 +235,6 @@ public class PvPEventHandler
         PvPUtils.green (player, "PvP is now disabled for you.");
     }
 
-    void sendCooldown(EntityPlayerMP player)
-    {
-        PvPUtils.yellow (player, "You can switch PvP modes again in " + PvPMode.cooldown + " seconds");
-    }
-
     public static void init()
     {
         INSTANCE = new PvPEventHandler ();


### PR DESCRIPTION
This is why I'm using `String.format`. I also saw that this function currently is unused (@VulcanForge ). Should we remove it or do we want to keep it?