### PR TITLE
Encapsulated pvp data access - closes #15

### DIFF
--- a/main/java/pvpmode/PvPEventHandler.java
+++ b/main/java/pvpmode/PvPEventHandler.java
@@ -6,7 +6,6 @@ import cpw.mods.fml.common.FMLLog;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import net.minecraft.entity.*;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.*;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
@@ -35,8 +34,8 @@ public class PvPEventHandler
         if (attacker == null || victim == null)
             return;
 
-        NBTTagCompound attackerData = PvPUtils.getPvPData (attacker);
-        NBTTagCompound victimData = PvPUtils.getPvPData (victim);
+        PvpData attackerData = PvPUtils.getPvPData (attacker);
+        PvpData victimData = PvPUtils.getPvPData (victim);
 
         if (attacker.capabilities.allowFlying)
         {
@@ -62,7 +61,7 @@ public class PvPEventHandler
             return;
         }
 
-        if (!victimData.getBoolean ("PvPEnabled"))
+        if (!victimData.isPvpEnabled ())
         {
             if (attacker == event.source.getEntity ())
                 disabled (attacker);
@@ -71,7 +70,7 @@ public class PvPEventHandler
             return;
         }
 
-        if (!attackerData.getBoolean ("PvPEnabled"))
+        if (!attackerData.isPvpEnabled ())
         {
             event.setCanceled (true);
             return;
@@ -95,26 +94,26 @@ public class PvPEventHandler
             player = (EntityPlayerMP) event.entityLiving;
         else return;
 
-        NBTTagCompound data = PvPUtils.getPvPData (player);
+        PvpData data = PvPUtils.getPvPData (player);
 
-        long toggleTime = data.getLong ("PvPWarmup");
+        long toggleTime = data.getPvpWarmup ();
 
         if (toggleTime != 0 && toggleTime < time)
         {
-            data.setLong ("PvPWarmup", 0);
+            data.setPvpWarmup (0);
 
-            if (!data.getBoolean ("PvPEnabled"))
+            if (!data.isPvpEnabled ())
             {
-                data.setBoolean ("PvPEnabled", true);
+                data.setPvpEnabled (true);
                 warnServer (player);
             }
             else
             {
-                data.setBoolean ("PvPEnabled", false);
+                data.setPvpEnabled (false);
                 pvpOff (player);
             }
 
-            data.setLong ("PvPCooldown", time + PvPMode.cooldown);
+            data.setPvpCooldown (time + PvPMode.cooldown);
         }
     }
 

--- a/main/java/pvpmode/PvPUtils.java
+++ b/main/java/pvpmode/PvPUtils.java
@@ -2,12 +2,9 @@ package pvpmode;
 
 import cpw.mods.fml.common.Loader;
 import net.minecraft.command.ICommandSender;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.entity.player.*;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.util.ChatComponentText;
-import net.minecraft.util.EnumChatFormatting;
+import net.minecraft.util.*;
 
 public class PvPUtils
 {
@@ -51,44 +48,12 @@ public class PvPUtils
     }
 
     /**
-     * Returns the data tag from which all player-specific PvP properties can be
-     * accessed.
+     * Returns a wrapper from which all player-specific PvP properties can be
+     * accessed. The returned instance can be returned from a cache.
      */
-    public static NBTTagCompound getPvPData(EntityPlayer player)
+    public static PvpData getPvPData(EntityPlayer player)
     {
-        NBTTagCompound data = player.getEntityData ();
-        NBTTagCompound persistent;
-        NBTTagCompound pvpData;
-
-        if (!data.hasKey (EntityPlayer.PERSISTED_NBT_TAG))
-        {
-            persistent = new NBTTagCompound ();
-            data.setTag (EntityPlayer.PERSISTED_NBT_TAG, persistent);
-        }
-
-        persistent = data.getCompoundTag (EntityPlayer.PERSISTED_NBT_TAG);
-
-        if (!persistent.hasKey ("PvPData"))
-        {
-            pvpData = new NBTTagCompound ();
-            persistent.setTag ("PvPData", pvpData);
-        }
-
-        pvpData = persistent.getCompoundTag ("PvPData");
-
-        if (!pvpData.hasKey ("PvPEnabled"))
-            pvpData.setBoolean ("PvPEnabled", false);
-
-        if (!pvpData.hasKey ("PvPWarmup"))
-            pvpData.setLong ("PvPWarmup", 0);
-
-        if (!pvpData.hasKey ("PvPCooldown"))
-            pvpData.setLong ("PvPCooldown", 0);
-
-        if (!pvpData.hasKey ("PvPTag"))
-            pvpData.setLong ("PvPTag", 0);
-
-        return pvpData;
+       return new PvpData (player);
     }
 
     /**

--- a/main/java/pvpmode/PvpData.java
+++ b/main/java/pvpmode/PvpData.java
@@ -18,7 +18,6 @@ public class PvpData
     private static final String PVP_ENABLED_NBT_KEY = "PvPEnabled";
     private static final String PVP_WARMUP_NBT_KEY = "PvPWarmup";
     private static final String PVP_COOLDOWN_NBT_KEY = "PvPCooldown";
-    private static final String PVP_TAG_NBT_KEY = "PvPTag";
 
     public PvpData (EntityPlayer player)
     {
@@ -70,16 +69,6 @@ public class PvpData
     public void setPvpCooldown (long pvpCooldown)
     {
         pvpDataTag.setLong (PVP_COOLDOWN_NBT_KEY, pvpCooldown);
-    }
-
-    public long getPvpTag ()
-    {
-        return pvpDataTag.getLong (PVP_TAG_NBT_KEY);
-    }
-
-    public void setPvpTag (long pvpTag)
-    {
-        pvpDataTag.setLong (PVP_TAG_NBT_KEY, pvpTag);
     }
 
 }

--- a/main/java/pvpmode/PvpData.java
+++ b/main/java/pvpmode/PvpData.java
@@ -1,0 +1,85 @@
+package pvpmode;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.NBTTagCompound;
+
+/**
+ * A wrapper for accessing the data PvpMode stores about each player.
+ * 
+ * @author CraftedMods
+ *
+ */
+public class PvpData
+{
+    private NBTTagCompound pvpDataTag;
+
+    private static final String PVP_DATA_NBT_KEY = "PvPData";
+
+    private static final String PVP_ENABLED_NBT_KEY = "PvPEnabled";
+    private static final String PVP_WARMUP_NBT_KEY = "PvPWarmup";
+    private static final String PVP_COOLDOWN_NBT_KEY = "PvPCooldown";
+    private static final String PVP_TAG_NBT_KEY = "PvPTag";
+
+    public PvpData (EntityPlayer player)
+    {
+        NBTTagCompound data = player.getEntityData ();
+        NBTTagCompound persistent;
+
+        if (!data.hasKey (EntityPlayer.PERSISTED_NBT_TAG))
+        {
+            persistent = new NBTTagCompound ();
+            data.setTag (EntityPlayer.PERSISTED_NBT_TAG, persistent);
+        }
+
+        persistent = data.getCompoundTag (EntityPlayer.PERSISTED_NBT_TAG);
+
+        if (!persistent.hasKey (PVP_DATA_NBT_KEY))
+        {
+            pvpDataTag = new NBTTagCompound ();
+            persistent.setTag (PVP_DATA_NBT_KEY, pvpDataTag);
+        }
+
+        pvpDataTag = persistent.getCompoundTag (PVP_DATA_NBT_KEY);
+    }
+
+    public boolean isPvpEnabled ()
+    {
+        return pvpDataTag.getBoolean (PVP_ENABLED_NBT_KEY);
+    }
+
+    public void setPvpEnabled (boolean pvpEnabled)
+    {
+        pvpDataTag.setBoolean (PVP_ENABLED_NBT_KEY, pvpEnabled);
+    }
+
+    public long getPvpWarmup ()
+    {
+        return pvpDataTag.getLong (PVP_WARMUP_NBT_KEY);
+    }
+
+    public void setPvpWarmup (long pvpWarmup)
+    {
+        pvpDataTag.setLong (PVP_WARMUP_NBT_KEY, pvpWarmup);
+    }
+
+    public long getPvpCooldown ()
+    {
+        return pvpDataTag.getLong (PVP_COOLDOWN_NBT_KEY);
+    }
+
+    public void setPvpCooldown (long pvpCooldown)
+    {
+        pvpDataTag.setLong (PVP_COOLDOWN_NBT_KEY, pvpCooldown);
+    }
+
+    public long getPvpTag ()
+    {
+        return pvpDataTag.getLong (PVP_TAG_NBT_KEY);
+    }
+
+    public void setPvpTag (long pvpTag)
+    {
+        pvpDataTag.setLong (PVP_TAG_NBT_KEY, pvpTag);
+    }
+
+}

--- a/main/java/pvpmode/command/PvPCommand.java
+++ b/main/java/pvpmode/command/PvPCommand.java
@@ -1,11 +1,8 @@
 package pvpmode.command;
 
-import net.minecraft.command.CommandBase;
-import net.minecraft.command.ICommandSender;
+import net.minecraft.command.*;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.nbt.NBTTagCompound;
-import pvpmode.PvPMode;
-import pvpmode.PvPUtils;
+import pvpmode.*;
 
 public class PvPCommand extends CommandBase
 {
@@ -31,11 +28,11 @@ public class PvPCommand extends CommandBase
     public void processCommand(ICommandSender sender, String[] args)
     {
         EntityPlayerMP player = getCommandSenderAsPlayer (sender);
-        NBTTagCompound data = PvPUtils.getPvPData (player);
+        PvpData data = PvPUtils.getPvPData (player);
 
         long time = PvPUtils.getTime ();
         long toggleTime = time + PvPMode.warmup;
-        long cooldownTime = data.getLong ("PvPCooldown");
+        long cooldownTime = data.getPvpCooldown ();
 
         String message;
 
@@ -47,10 +44,10 @@ public class PvPCommand extends CommandBase
             return;
         }
 
-        data.setLong ("PvPWarmup", toggleTime);
-        data.setLong ("PvPCooldown", 0);
+        data.setPvpWarmup (toggleTime);
+        data.setPvpCooldown (0);
 
-        String status = data.getBoolean ("PvPEnabled") ? "disabled" : "enabled";
+        String status = data.isPvpEnabled () ? "disabled" : "enabled";
         message = "PvP will be " + status + " in " + PvPMode.warmup + " seconds...";
         PvPUtils.yellow (sender, message);
     }

--- a/main/java/pvpmode/command/PvPCommandAdmin.java
+++ b/main/java/pvpmode/command/PvPCommandAdmin.java
@@ -50,7 +50,7 @@ public class PvPCommandAdmin extends CommandBase
          * secrecy.
          */
         warnPlayer (player);
-        PvPUtils.getPvPData (player).setLong ("PvPWarmup", PvPUtils.getTime ());
+        PvPUtils.getPvPData (player).setPvpWarmup (PvPUtils.getTime ());
     }
 
     @Override

--- a/main/java/pvpmode/command/PvPCommandCancel.java
+++ b/main/java/pvpmode/command/PvPCommandCancel.java
@@ -1,10 +1,8 @@
 package pvpmode.command;
 
-import net.minecraft.command.CommandBase;
-import net.minecraft.command.ICommandSender;
+import net.minecraft.command.*;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.nbt.NBTTagCompound;
-import pvpmode.PvPUtils;
+import pvpmode.*;
 
 public class PvPCommandCancel extends CommandBase
 {
@@ -30,14 +28,14 @@ public class PvPCommandCancel extends CommandBase
     public void processCommand(ICommandSender sender, String[] args)
     {
         EntityPlayerMP player = getCommandSenderAsPlayer (sender);
-        NBTTagCompound data = PvPUtils.getPvPData (player);
-        long warmup = data.getLong ("PvPWarmup");
+        PvpData data = PvPUtils.getPvPData (player);
+        long warmup = data.getPvpWarmup ();
 
         if (warmup == 0)
             PvPUtils.yellow (sender, "No PvP warmup to cancel.");
         else
         {
-            data.setLong ("PvPWarmup", 0);
+            data.setPvpWarmup (0);
             PvPUtils.yellow (sender, "PvP warmup canceled.");
         }
     }

--- a/main/java/pvpmode/command/PvPCommandList.java
+++ b/main/java/pvpmode/command/PvPCommandList.java
@@ -2,14 +2,10 @@ package pvpmode.command;
 
 import java.util.ArrayList;
 
-import net.minecraft.command.CommandBase;
-import net.minecraft.command.ICommandSender;
+import net.minecraft.command.*;
 import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.ChatComponentText;
-import net.minecraft.util.EnumChatFormatting;
-import pvpmode.PvPMode;
-import pvpmode.PvPUtils;
+import net.minecraft.util.*;
+import pvpmode.*;
 
 public class PvPCommandList extends CommandBase
 {
@@ -41,15 +37,15 @@ public class PvPCommandList extends CommandBase
         for (Object o : PvPMode.cfg.playerEntityList)
         {
             EntityPlayerMP player = (EntityPlayerMP) o;
-            NBTTagCompound playerData = PvPUtils.getPvPData (player);
+            PvpData playerData = PvPUtils.getPvPData (player);
 
             if (player.capabilities.isCreativeMode)
                 safePlayers.add ("[GM1] " + player.getDisplayName ());
             else if (player.capabilities.allowFlying)
                 safePlayers.add ("[FLY] " + player.getDisplayName ());
-            else if (!playerData.getBoolean ("PvPEnabled"))
+            else if (!playerData.isPvpEnabled ())
             {
-                long warmup = playerData.getLong ("PvPWarmup");
+                long warmup = playerData.getPvpWarmup ();
 
                 if (warmup == 0)
                     safePlayers.add ("[OFF] " + player.getDisplayName ());
@@ -61,7 +57,7 @@ public class PvPCommandList extends CommandBase
             {
                 String message = EnumChatFormatting.RED + "[ON] " + player.getDisplayName ();
 
-                if (PvPUtils.getPvPData (senderPlayer).getBoolean ("PvPEnabled") && PvPMode.radar
+                if (PvPUtils.getPvPData (senderPlayer).isPvpEnabled () && PvPMode.radar
                                 && senderPlayer != player)
                     message += " - ~" + roundedDistanceBetween (senderPlayer, player) + " blocks";
 


### PR DESCRIPTION
From now on, accessing the pvp data is easier and less error-prone. I left the function `PvpUtils.getPvpdata` because accessing the data can be further optimized - the `PvpData` instances can be cached (so creating them directly should be avoided). But this is a feature for the near future. I'll open an issue for this if the PR has been merged.  
~~Also I found a property `PvpTag`.  I couldn't found an usage for it in the code, but I've added it to the wrapper. If we can remove it because it's no longer needed, I would like to append the relevant commit to this PR (@VulcanForge ).~~