### PR TITLE
Added an attack warning if the attacker has PvP disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * The changelog will now be integrated into the JAR of PvPMode
 * Restructured the internal handling of compatibility-related code (added compatibility modules)
 * Improved the performance if the LOTR Mod is present
+* Added a warning if the attacking player has PvP disabled
 
 ## 1.0.0-BETA
 * Added combat logging (two handlers: csv (default) and simple)

--- a/src/main/java/pvpmode/PvPEventHandler.java
+++ b/src/main/java/pvpmode/PvPEventHandler.java
@@ -44,6 +44,10 @@ public class PvPEventHandler
                 {
                     PvPUtils.red (attacker, "You are in fly mode!");
                 }
+                else
+                {
+                    PvPUtils.red (attacker, "You have PvP disabled!");
+                }
             }
             cancel = true;
         }


### PR DESCRIPTION
We could even count this as a bug, that such an essential warning is missing.