### PR TITLE
Fixed a crash in the compatibility module loader

### DIFF
--- a/src/main/java/pvpmode/compatibility/CompatibilityManager.java
+++ b/src/main/java/pvpmode/compatibility/CompatibilityManager.java
@@ -104,7 +104,8 @@ public class CompatibilityManager
                     {
                         FMLLog.getLogger ()
                             .error (
-                                String.format ("The specified compatibility module class \"%s\" couldn't be found"));
+                                String.format ("The specified compatibility module class \"%s\" couldn't be found",
+                                    loader.getCompatibilityModuleClassName ()));
                     }
                 }
                 else


### PR DESCRIPTION
A format argument was missing which causes a crash if the specified compatibility module is missing.