### PR TITLE
Sort the players listed in /pvplist with PvP enabled based on their proximity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * The calling player of `pvplist` now will always be displayed on the top of the list
 * Added a footer to the `pvphelp` command list
 * Added a header and a footer to the `pvplist` player list
+* Players in the `pvplist` list with PvP enabled are now sorted by their proximity (if radar is enabled)
 
 ## 1.0.0-BETA
 * Added combat logging (two handlers: csv (default) and simple)


### PR DESCRIPTION
Closes #63. This only applies if the PvP radar is enabled.