### PR TITLE
Changed the PvP timer's default and maximum value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Transferring items via shift-clicking in the player's inventory during PvP is now disableable
 * If an inventory contains less stacks than have to be dropped, the game can optionally scan other inventories
 * Players can now optionally decide with `pvp spy [on|off]` whether they want to provide/receive proximity informations
+* Increased the default PvP timer value to 45 seconds
+* Increased the maximum possible value of the PvP timer to 300 seconds
 
 ### LOTR compatibility:
 * Players now optionally drop their skulls when killed with a weapon with the headhunter modifier even if keepInventory is on

--- a/src/main/java/pvpmode/PvPMode.java
+++ b/src/main/java/pvpmode/PvPMode.java
@@ -87,7 +87,7 @@ public class PvPMode
         overrideCheckInterval = config.getInt ("PvP Mode Override Check Interval (Seconds)",
             MAIN_CONFIGURATION_CATEGORY, 10, -1, 60,
             "Specifies how often the mod checks for PvP mode overrides. If set to zero, the checks will be executed every tick. Set it to -1 to disable the PvP mode overrides.");
-        pvpTimer = config.getInt ("PvP Timer (Seconds)", MAIN_CONFIGURATION_CATEGORY, 30, 10, 60,
+        pvpTimer = config.getInt ("PvP Timer (Seconds)", MAIN_CONFIGURATION_CATEGORY, 45, 10, 300,
             "Specifies the time interval after a combat event while which all involved players are seen as \"in PvP\".");
         commandBlacklist = new HashSet<> (Arrays.asList (
             config.getStringList ("Command Blacklist", MAIN_CONFIGURATION_CATEGORY, new String[] {},


### PR DESCRIPTION
We just thought that they're too low, so now they're increased.